### PR TITLE
Fix AppbarHeader elevation on Android

### DIFF
--- a/src/components/Appbar/AppbarHeader.js
+++ b/src/components/Appbar/AppbarHeader.js
@@ -111,7 +111,7 @@ class AppbarHeader extends React.Component<Props> {
 
     return (
       <Wrapper
-        style={[{ backgroundColor, zIndex }, elevation && shadow(elevation)]}
+        style={[{ backgroundColor, zIndex }, elevation && {shadow(elevation), elevation}]}
       >
         {/* $FlowFixMe: There seems to be conflict between Appbar's props and Header's props */}
         <Appbar


### PR DESCRIPTION
The Appbar.Header had no elevation in Android. This is because you did not write the elevation property when you passed it to style prop.
Tip: Add the elevation property in the shadow function return